### PR TITLE
Fix: Scale icon border thickness with icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                                 step="1"
                                 class="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                             >
-                            <span id="border-size-display" class="text-sm font-medium text-gray-600 min-w-[40px]">0px</span>
+                            <span id="border-size-display" class="text-sm font-medium text-gray-600 min-w-[40px]">0%</span>
                         </div>
                     </div>
                 </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,7 @@ function initializeEventListeners(): void {
   if (borderSlider && borderDisplay) {
     borderSlider.addEventListener('input', (e) => {
       const target = e.target as HTMLInputElement;
-      borderDisplay.textContent = `${target.value}px`;
+      borderDisplay.textContent = `${target.value}%`; // Changed to %
     });
   }
 

--- a/src/qrCode.ts
+++ b/src/qrCode.ts
@@ -71,7 +71,7 @@ function addIconToQRCode(
   iconSrc: string,
   transparentBg = false,
   logoSizeRatio = 0.2,
-  borderSize = 0,
+  borderSizePercentage = 0, // Renamed from borderSize
 ): Promise<void> {
   return new Promise((resolve) => {
     const ctx = canvas.getContext('2d');
@@ -87,19 +87,23 @@ function addIconToQRCode(
       const iconX = (canvas.width - iconSize) / 2;
       const iconY = (canvas.height - iconSize) / 2;
 
+      // Calculate actual border size in pixels
+      const borderSizeInPixels = (iconSize * borderSizePercentage) / 100;
+
       // Only add background if not using transparent background
-      if (!transparentBg && borderSize > 0) {
+      if (!transparentBg && borderSizeInPixels > 0) {
         ctx.save();
 
-        // Fixed border radius for consistent appearance
-        const borderRadius = Math.min(borderSize * 0.5, 4);
+        // Dynamic border radius, proportional to border size
+        // Max radius can be, for example, 20% of borderSizeInPixels or a portion of iconSize
+        const borderRadius = Math.min(borderSizeInPixels * 0.5, iconSize * 0.1, 8); // Capped at 8px max for very large icons/borders
         ctx.fillStyle = 'white';
         ctx.beginPath();
         ctx.roundRect(
-          iconX - borderSize,
-          iconY - borderSize,
-          iconSize + borderSize * 2,
-          iconSize + borderSize * 2,
+          iconX - borderSizeInPixels,
+          iconY - borderSizeInPixels,
+          iconSize + borderSizeInPixels * 2,
+          iconSize + borderSizeInPixels * 2,
           borderRadius,
         );
         ctx.fill();


### PR DESCRIPTION
The icon border thickness was previously a fixed pixel value, causing it to appear disproportionately small for larger icons and vice-versa.

This commit modifies the icon generation logic to calculate the border thickness as a percentage of the icon's actual size. This ensures the border scales proportionally with the icon.

Changes include:
- Updated `addIconToQRCode` to use a border size percentage.
- Adjusted border radius calculation to be proportional to the new dynamic border size.
- Updated UI display in `index.html` and `main.ts` to reflect border size as a percentage.